### PR TITLE
fix!: enforce only a single cert refresh setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Flags:
       --influx                      Enable InfluxDB Line Protocol
       --port int                    Prometheus exporter HTTP port (default 9333)
       --prometheus                  Enable prometheus exporter, default if nothing else
-      --refresh-interval duration   How many sec between metrics update (default 1m0s)
   -v, --verbose                     Enable verbose
 
 Use " [command] --help" for more information about a command.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,11 +55,6 @@ func init() {
 	if err := viper.BindPFlag("fetch_interval", flags.Lookup("fetch-interval")); err != nil {
 		log.Fatal(err)
 	}
-
-	flags.Duration("refresh-interval", time.Minute, "How many sec between metrics update")
-	if err := viper.BindPFlag("refresh_interval", flags.Lookup("refresh-interval")); err != nil {
-		log.Fatal(err)
-	}
 }
 
 func main() {
@@ -80,15 +75,12 @@ func entrypoint() {
 		log.Errorln(err.Error())
 	}
 
-	pkiMon.Watch(viper.GetDuration("fetch_interval"))
-
 	if viper.GetBool("prometheus") || !viper.GetBool("influx") {
-		log.Infoln("start prometheus exporter")
-		vaultMon.PromWatchCerts(&pkiMon, viper.GetDuration("refresh_interval"))
+		vaultMon.PromWatchCerts(&pkiMon, viper.GetDuration("fetch_interval"))
 		vaultMon.PromStartExporter(viper.GetInt("port"))
 	}
 
 	if viper.GetBool("influx") {
-		vaultMon.InfluxWatchCerts(&pkiMon, viper.GetDuration("refresh_interval"), viper.GetBool("prometheus"))
+		vaultMon.InfluxWatchCerts(&pkiMon, viper.GetDuration("fetch_interval"), viper.GetBool("prometheus"))
 	}
 }

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -63,27 +63,23 @@ func (mon *PKIMon) loadPKI() error {
 	return nil
 }
 
-func (mon *PKIMon) Watch(interval time.Duration) {
+func (mon *PKIMon) Watch() {
 	log.Infoln("Start watching pki certs")
-	go func() {
-		for {
-			log.Infoln("Refresh PKI list")
-			err := mon.loadPKI()
-			if err != nil {
-				log.Errorln(err)
-			}
-			for _, pki := range mon.pkis {
-				log.Infof("Refresh PKI certificate for %s", pki.path)
-				pki.clearCerts()
-				err := pki.loadCerts()
-				if err != nil {
-					log.Errorln(err)
-				}
-			}
-			mon.Loaded = true
-			time.Sleep(interval)
+
+	log.Infoln("Refresh PKI list")
+	err := mon.loadPKI()
+	if err != nil {
+		log.Errorln(err)
+	}
+	for _, pki := range mon.pkis {
+		log.Infof("Refresh PKI certificate for %s", pki.path)
+		pki.clearCerts()
+		err := pki.loadCerts()
+		if err != nil {
+			log.Errorln(err)
 		}
-	}()
+	}
+	mon.Loaded = true
 }
 
 func (mon *PKIMon) GetPKIs() map[string]*PKI {


### PR DESCRIPTION
This change simplifies the two interval flags, `refresh-interval` and `fetch-interval` into solely `fetch-interval`.

The previous behavior was confusing and buggy - in order to reduce load on a Vault server with a high `fetch-interval`, certificate metrics will have long stale gaps and will not be displayed despite a high `refresh-interval`.

Instead, this simplifies the behavior of the two flags into just `fetch-interval`. Now, the one setting will control how often the exporter reaches out to Vault and will not display any stale metrics in the mean time.

BREAKING CHANGE: refresh-interval flag no longer supported