### PR TITLE
Revert "fix!: enforce only a single cert refresh setting"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Flags:
       --influx                      Enable InfluxDB Line Protocol
       --port int                    Prometheus exporter HTTP port (default 9333)
       --prometheus                  Enable prometheus exporter, default if nothing else
+      --refresh-interval duration   How many sec between metrics update (default 1m0s)
   -v, --verbose                     Enable verbose
 
 Use " [command] --help" for more information about a command.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,6 +55,11 @@ func init() {
 	if err := viper.BindPFlag("fetch_interval", flags.Lookup("fetch-interval")); err != nil {
 		log.Fatal(err)
 	}
+
+	flags.Duration("refresh-interval", time.Minute, "How many sec between metrics update")
+	if err := viper.BindPFlag("refresh_interval", flags.Lookup("refresh-interval")); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func main() {
@@ -75,12 +80,15 @@ func entrypoint() {
 		log.Errorln(err.Error())
 	}
 
+	pkiMon.Watch(viper.GetDuration("fetch_interval"))
+
 	if viper.GetBool("prometheus") || !viper.GetBool("influx") {
-		vaultMon.PromWatchCerts(&pkiMon, viper.GetDuration("fetch_interval"))
+		log.Infoln("start prometheus exporter")
+		vaultMon.PromWatchCerts(&pkiMon, viper.GetDuration("refresh_interval"))
 		vaultMon.PromStartExporter(viper.GetInt("port"))
 	}
 
 	if viper.GetBool("influx") {
-		vaultMon.InfluxWatchCerts(&pkiMon, viper.GetDuration("fetch_interval"), viper.GetBool("prometheus"))
+		vaultMon.InfluxWatchCerts(&pkiMon, viper.GetDuration("refresh_interval"), viper.GetBool("prometheus"))
 	}
 }

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -63,23 +63,27 @@ func (mon *PKIMon) loadPKI() error {
 	return nil
 }
 
-func (mon *PKIMon) Watch() {
+func (mon *PKIMon) Watch(interval time.Duration) {
 	log.Infoln("Start watching pki certs")
-
-	log.Infoln("Refresh PKI list")
-	err := mon.loadPKI()
-	if err != nil {
-		log.Errorln(err)
-	}
-	for _, pki := range mon.pkis {
-		log.Infof("Refresh PKI certificate for %s", pki.path)
-		pki.clearCerts()
-		err := pki.loadCerts()
-		if err != nil {
-			log.Errorln(err)
+	go func() {
+		for {
+			log.Infoln("Refresh PKI list")
+			err := mon.loadPKI()
+			if err != nil {
+				log.Errorln(err)
+			}
+			for _, pki := range mon.pkis {
+				log.Infof("Refresh PKI certificate for %s", pki.path)
+				pki.clearCerts()
+				err := pki.loadCerts()
+				if err != nil {
+					log.Errorln(err)
+				}
+			}
+			mon.Loaded = true
+			time.Sleep(interval)
 		}
-	}
-	mon.Loaded = true
+	}()
 }
 
 func (mon *PKIMon) GetPKIs() map[string]*PKI {

--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -3,12 +3,10 @@ package vault_mon
 import (
 	"crypto/x509"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
-
-	log "github.com/aarnaud/vault-pki-exporter/pkg/logger"
-	"github.com/spf13/viper"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -68,7 +66,6 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 	}, []string{"source"})
 	go func() {
 		for {
-			pkimon.Watch()
 			pkis := pkimon.GetPKIs()
 			expiry.Reset()
 			age.Reset()
@@ -95,9 +92,6 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 				certcount.WithLabelValues(pkiname).Set(float64(len(pki.certs)))
 				expired_cert_count.WithLabelValues(pkiname).Set(float64(pki.expiredCertsCounter))
 			}
-			if viper.GetBool("verbose") {
-				log.WithField("interval", interval).Infoln("Sleeping")
-			}
 			time.Sleep(interval)
 		}
 	}()
@@ -119,7 +113,6 @@ func getLabelValues(pkiname string, cert *x509.Certificate) []string {
 
 func PromStartExporter(port int) {
 	http.Handle("/metrics", promhttp.Handler())
-	log.Infoln("start prometheus exporter")
 	err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Reverts linode-obs/vault-pki-exporter#2

This doesn't do what it intends to