### PR TITLE
feat: allow throttling of requests-per-second to Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Flags:
       --prometheus                  Enable prometheus exporter, default if nothing else
       --refresh-interval duration   How many sec between metrics update (default 1m0s)
       --batch-size-percent          How large of a batch of certificates to get data for at once, supports floats (e.g 0.0 - 100.0) (default 1)
+      --request-limit float         Token-bucket limiter for number of requests per second to Vault when fetching certs (0 = disabled)
+      --request-limit-burst int     Token-bucket burst limit for number of requests per second to Vault when fetching certs (0 = match 'request-limit' value)
   -v, --verbose                     Enable verbose
 
 Use " [command] --help" for more information about a command.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,6 +66,16 @@ func init() {
 	if err := viper.BindPFlag("batch_size_percent", flags.Lookup("batch-size-percent")); err != nil {
 		log.Fatal(err)
 	}
+
+	flags.Float64("request-limit", 0.0, "Token-bucket limiter for number of requests per second to Vault when fetching certs (0 = disabled)")
+	if err := viper.BindPFlag("request_limit", flags.Lookup("request-limit")); err != nil {
+		log.Fatal(err)
+	}
+
+	flags.Int("request-limit-burst", 0, "Token-bucket burst limit for number of requests per second to Vault when fetching certs (0 = match 'request-limit' value)")
+	if err := viper.BindPFlag("request_limit_burst", flags.Lookup("request-limit-burst")); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func main() {

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,6 +28,7 @@ services:
       - ./vault-pki-exporter
       - --fetch-interval=5s
       - --refresh-interval=5s
+      - --verbose=true
     networks:
       - vault-pki-exporter
     ports:

--- a/pkg/vault-mon/influx.go
+++ b/pkg/vault-mon/influx.go
@@ -39,13 +39,16 @@ func influxProcessData(pkimon *PKIMon) {
 		if crl := pki.GetCRL(); crl != nil {
 			printCrlInfluxPoint(pkiname, crl)
 		}
-		for _, cert := range pki.GetCerts() {
-			printCertificateInfluxPoint(pkiname, cert)
+
+		for commonName, orgUnits := range pki.GetCerts() {
+			for orgUnit, cert := range orgUnits {
+				printCertificateInfluxPoint(pkiname, commonName, orgUnit, cert)
+			}
 		}
 	}
 }
 
-func printCertificateInfluxPoint(pkiname string, cert *x509.Certificate) {
+func printCertificateInfluxPoint(pkiname, commonName, orgUnit string, cert *x509.Certificate) {
 	now := time.Now()
 	point := influx.Point{
 		Measurement: "x509_cert",
@@ -53,9 +56,9 @@ func printCertificateInfluxPoint(pkiname string, cert *x509.Certificate) {
 			"host":                hostname,
 			"source":              pkiname,
 			"serial":              strings.ReplaceAll(fmt.Sprintf("% x", cert.SerialNumber.Bytes()), " ", "-"),
-			"common_name":         cert.Subject.CommonName,
+			"common_name":         commonName,
 			"organization":        getEmptyStringIfEmpty(cert.Subject.Organization),
-			"organizational_unit": getEmptyStringIfEmpty(cert.Subject.OrganizationalUnit),
+			"organizational_unit": orgUnit,
 			"country":             getEmptyStringIfEmpty(cert.Subject.Country),
 			"province":            getEmptyStringIfEmpty(cert.Subject.Province),
 			"locality":            getEmptyStringIfEmpty(cert.Subject.Locality),

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -227,14 +228,28 @@ func (pki *PKI) loadCerts() error {
 				if certInMap, ok := pki.certs[cert.Subject.CommonName]; ok && certInMap.NotAfter.Unix() < cert.NotAfter.Unix() {
 					pki.certs[cert.Subject.CommonName] = cert
 					if viper.GetBool("verbose") {
-						log.WithField("common_name", cert.Subject.CommonName).Infof("cert in map")
+						log.WithFields(logrus.Fields{
+							"organizational_unit": cert.Issuer.OrganizationalUnit,
+							"serial_number":       cert.SerialNumber.String(),
+							"common_name":         cert.Subject.CommonName,
+							"organization":        cert.Subject.Organization,
+							"not_before":          cert.NotBefore,
+							"not_after":           cert.NotAfter,
+						}).Infof("cert in map")
 					}
 				}
 
 				if cert.NotAfter.Unix() < time.Now().Unix() {
 					pki.expiredCertsCounter++
 					if viper.GetBool("verbose") {
-						log.WithField("common_name", cert.Subject.CommonName).Infof("cert rejected as expired")
+						log.WithFields(logrus.Fields{
+							"organizational_unit": cert.Issuer.OrganizationalUnit,
+							"serial_number":       cert.SerialNumber.String(),
+							"common_name":         cert.Subject.CommonName,
+							"organization":        cert.Subject.Organization,
+							"not_before":          cert.NotBefore,
+							"not_after":           cert.NotAfter,
+						}).Infof("cert rejected as expired")
 					}
 				}
 

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -226,10 +226,16 @@ func (pki *PKI) loadCerts() error {
 				// if already in map check the expiration
 				if certInMap, ok := pki.certs[cert.Subject.CommonName]; ok && certInMap.NotAfter.Unix() < cert.NotAfter.Unix() {
 					pki.certs[cert.Subject.CommonName] = cert
+					if viper.GetBool("verbose") {
+						log.WithField("common_name", cert.Subject.CommonName).Infof("cert in map")
+					}
 				}
 
 				if cert.NotAfter.Unix() < time.Now().Unix() {
 					pki.expiredCertsCounter++
+					if viper.GetBool("verbose") {
+						log.WithField("common_name", cert.Subject.CommonName).Infof("cert rejected as expired")
+					}
 				}
 
 				if _, ok := pki.certs[cert.Subject.CommonName]; !ok && cert.NotAfter.Unix() > time.Now().Unix() {


### PR DESCRIPTION
In instances where Vault has a bunch of certificates, you can essentially DoS Vault with all your requests. Instead of spamming all of the requests as fast as you can, this allows you to throttle how many requests per second you send to Vault by using a simple token-bucket rate limiter.

The limiter is off by default, so this does not change existing default behavior.

---
TODO:

- [ ] There's still a mutex on `GetCerts()` which seems less-than-ideal for intentionally slow loading of certs like this. There'll be a long delay before metrics are available when certs are first loaded.
    - [ ]  We should consider additional refactoring to allow Prometheus to return partial data during initial load and prior data during subsequent loads.