### PR TITLE
fix: rename time log to interval

### DIFF
--- a/pkg/vault-mon/influx.go
+++ b/pkg/vault-mon/influx.go
@@ -22,7 +22,7 @@ func InfluxWatchCerts(pkimon *PKIMon, interval time.Duration, loop bool) {
 		go func() {
 			for {
 				influxProcessData(pkimon)
-				slog.Info("Sleeping after processing influx data", "time", interval)
+				slog.Info("Sleeping after processing influx data", "interval", interval)
 				time.Sleep(interval)
 			}
 		}()

--- a/pkg/vault-mon/pki.go
+++ b/pkg/vault-mon/pki.go
@@ -104,7 +104,7 @@ func (mon *PKIMon) Watch(interval time.Duration) {
 				}
 			}
 			mon.Loaded = true
-			slog.Info("Sleeping after refreshing PKI certs", "time", interval)
+			slog.Info("Sleeping after refreshing PKI certs", "interval", interval)
 			time.Sleep(interval)
 		}
 	}()

--- a/pkg/vault-mon/prometheus.go
+++ b/pkg/vault-mon/prometheus.go
@@ -128,7 +128,7 @@ func PromWatchCerts(pkimon *PKIMon, interval time.Duration) {
 
 				duration := time.Since(startTime).Seconds()
 				promWatchCertsDuration.Observe(duration)
-				slog.Info("Sleeping after PromWatchCerts loop completed", "duration_seconds", duration, "pkis_processed", len(pkis), "time", interval)
+				slog.Info("Sleeping after PromWatchCerts loop completed", "duration_seconds", duration, "pkis_processed", len(pkis), "interval", interval)
 				time.Sleep(interval)
 			}
 		}

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -115,7 +115,7 @@ func (vault *ClientWrapper) GetSecret(path string, fn secretCallback) error {
 		if secret.LeaseDuration > 0 {
 			go func() {
 				for {
-					slog.Info("Sleeping before refreshing vault", "time", time.Duration(secret.LeaseDuration))
+					slog.Info("Sleeping before refreshing vault", "interval", time.Duration(secret.LeaseDuration))
 					time.Sleep(time.Duration(secret.LeaseDuration) * time.Second)
 					secret, err = vault.Client.Logical().Read(path)
 					if err != nil {
@@ -176,7 +176,7 @@ func watch_renewer_vault(renewer *vaultapi.Renewer) {
 	go func() {
 		for {
 			// Prevent loop when secret wasn't renewed before expiration
-			slog.Info("Waiting before calling another renew", "time", time.Second)
+			slog.Info("Waiting before calling another renew", "interval", time.Second)
 			time.Sleep(time.Second)
 			renewer.Renew()
 		}


### PR DESCRIPTION
time is a standard log collector field, interval is better and won't conflict